### PR TITLE
Support parsing of CDT files for collision data, start but dont finish expanding parsing of adr

### DIFF
--- a/Editor/FileTypes/AdrFile.cs
+++ b/Editor/FileTypes/AdrFile.cs
@@ -75,8 +75,8 @@ namespace ForgeLightToolkit.Editor.FileTypes
                         break;
 
                     case EnumFileNameType.UpdateRadius:
-                        updateRadius = BitConverter.ToSingle(reader.ReadBytes(4).Reverse().ToArray());
-                        Debug.Log($"{adrFilePath} ur {updateRadius} ");
+                        byte[] bigEndianUpdateRadBytes = reader.ReadBytes(4);
+                        updateRadius = BitConverter.ToSingle(BitConverter.IsLittleEndian ? bigEndianUpdateRadBytes.Reverse().ToArray() : bigEndianUpdateRadBytes);
                         break;
 
                     default:

--- a/Editor/FileTypes/AdrFile.cs
+++ b/Editor/FileTypes/AdrFile.cs
@@ -1,15 +1,33 @@
-﻿#nullable enable
+#nullable enable
 
+using System;
+using System.Buffers.Binary;
 using System.IO;
-
+using System.Linq;
 using UnityEngine;
 
 namespace ForgeLightToolkit.Editor.FileTypes
 {
     public class AdrFile : ScriptableObject
     {
+        // TODO: use the Actor Tool Export, logic, facts, and knowledge (here in my garage) to parse as much data as possible from the ADRs in FLTK
+        public enum EnumPrimaryDataType : byte {
+            Unknown = 0,
+            FileName = 2,
+            CollisionData = 0x0D,
+        }
+
+        public enum EnumFileNameType : byte {
+            Unknown = 0,
+            ModelFile = 1,
+            MaterialFile = 2,
+            UpdateRadius = 3,
+        }
+
         public string? ModelFileName;
         public string? MaterialFileName;
+        public float updateRadius;
+        public string collisionFile;
 
         public bool Load(string filePath)
         {
@@ -19,14 +37,17 @@ namespace ForgeLightToolkit.Editor.FileTypes
 
             while (!reader.ReachedEnd)
             {
-                var definitionType = reader.ReadByte();
+                var definitionType = (EnumPrimaryDataType) reader.ReadByte();
                 var definitionSize = reader.ReadCompressedLength();
                 var definitionData = reader.ReadBytes(definitionSize);
 
                 switch (definitionType)
                 {
-                    case 2:
-                        ParseModelDefinition(definitionData);
+                    case EnumPrimaryDataType.FileName:
+                        ParseModelDefinition(definitionData, filePath);
+                        break;
+                    case EnumPrimaryDataType.CollisionData:
+                        ParseCollisionDefinition(definitionData, filePath);
                         break;
                 }
             }
@@ -34,23 +55,47 @@ namespace ForgeLightToolkit.Editor.FileTypes
             return true;
         }
 
-        private void ParseModelDefinition(byte[] data)
+        private void ParseModelDefinition(byte[] data, string adrFilePath)
         {
             var reader = new Reader(data);
 
             while (!reader.ReachedEnd)
             {
-                var definitionType = reader.ReadByte();
+                var definitionType = (EnumFileNameType) reader.ReadByte();
                 var definitionSize = reader.ReadCompressedLength();
 
                 switch (definitionType)
                 {
-                    case 1:
+                    case EnumFileNameType.ModelFile:
                         ModelFileName = reader.ReadNullTerminatedString();
                         break;
 
-                    case 2:
+                    case EnumFileNameType.MaterialFile:
                         MaterialFileName = reader.ReadNullTerminatedString();
+                        break;
+
+                    case EnumFileNameType.UpdateRadius:
+                        updateRadius = BitConverter.ToSingle(reader.ReadBytes(4).Reverse().ToArray());
+                        Debug.Log($"{adrFilePath} ur {updateRadius} ");
+                        break;
+
+                    default:
+                        reader.Skip(definitionSize);
+                        break;
+                }
+            }
+        }
+
+        private void ParseCollisionDefinition(byte[] data, string adrFilePath) {
+            var reader = new Reader(data);
+
+            while (!reader.ReachedEnd) {
+                var definitionType = reader.ReadByte();
+                var definitionSize = reader.ReadCompressedLength();
+
+                switch (definitionType) {
+                    case 1:
+                        collisionFile = reader.ReadNullTerminatedString();
                         break;
 
                     default:

--- a/Editor/FileTypes/CdtFile.cs
+++ b/Editor/FileTypes/CdtFile.cs
@@ -7,17 +7,17 @@ namespace ForgeLightToolkit.Editor.FileTypes {
         public enum EnumUnknownEnum : uint {
             Unknown = 0,
             Default = 0x01,
-            _0x02 = 0x02,
-            _0x03 = 0x03,
-            _0x05 = 0x05,
-            _0x0A = 0x0A,
-            _0x26 = 0x26,
-            _0x27 = 0x27,
-            _0x28 = 0x28,
-            _0x29 = 0x29,
-            _0x2A = 0x2A,
-            _0x2B = 0x2B,
-            _0x2C = 0x2C,
+            UnknownPurpose_0x02 = 0x02,
+            UnknownPurpose_0x03 = 0x03,
+            UnknownPurpose_0x05 = 0x05,
+            UnknownPurpose_0x0A = 0x0A,
+            UnknownPurpose_0x26 = 0x26,
+            UnknownPurpose_0x27 = 0x27,
+            UnknownPurpose_0x28 = 0x28,
+            UnknownPurpose_0x29 = 0x29,
+            UnknownPurpose_0x2A = 0x2A,
+            UnknownPurpose_0x2B = 0x2B,
+            UnknownPurpose_0x2C = 0x2C,
             HighBidDefault = 0x80000001
         }
 

--- a/Editor/FileTypes/CdtFile.cs
+++ b/Editor/FileTypes/CdtFile.cs
@@ -81,9 +81,14 @@ namespace ForgeLightToolkit.Editor.FileTypes {
                 indices.Add(reader.ReadUInt16());
             }
 
+            // because unity and forgelight disagree on the z axis, we need to reverse the indicies here to get the front face facing the right way
+            var reversedIndicies = new List<int>(indices);
+            reversedIndicies.Reverse();
+
             colliderMesh = new Mesh();
             colliderMesh.SetVertices(verticies);
-            colliderMesh.SetIndices(indices, MeshTopology.Triangles, 0);
+            colliderMesh.SetIndices(reversedIndicies, MeshTopology.Triangles, 0);
+            colliderMesh.name = $"{name}_Collider";
 
             // TODO: possible future, read what ever bullet physics data goes right here
 

--- a/Editor/FileTypes/CdtFile.cs
+++ b/Editor/FileTypes/CdtFile.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ForgeLightToolkit.Editor.FileTypes {
+    public class CdtFile : ScriptableObject {
+        public enum EnumUnknownEnum : uint {
+            Unknown = 0,
+            Default = 0x01,
+            _0x02 = 0x02,
+            _0x03 = 0x03,
+            _0x05 = 0x05,
+            _0x0A = 0x0A,
+            _0x26 = 0x26,
+            _0x27 = 0x27,
+            _0x28 = 0x28,
+            _0x29 = 0x29,
+            _0x2A = 0x2A,
+            _0x2B = 0x2B,
+            _0x2C = 0x2C,
+            HighBidDefault = 0x80000001
+        }
+
+        public List<Vector3> verticies = new();
+        public List<int> indices = new();
+        public EnumUnknownEnum unknownEnum;
+        public Mesh colliderMesh;
+
+        public bool Load(string filePath, byte[] buffer) {
+            name = Path.GetFileNameWithoutExtension(filePath);
+
+            var reader = new Reader(buffer);
+
+            return LoadInternal(reader);
+        }
+
+        public bool Load(string filePath) {
+            name = Path.GetFileNameWithoutExtension(filePath);
+
+            var reader = new Reader(File.OpenRead(filePath));
+
+            return LoadInternal(reader);
+        }
+
+        private bool LoadInternal(Reader reader) {
+            var magic = new string(reader.ReadChars(4));
+
+            if (magic != "CDTA") {
+                return false;
+            }
+
+            var version = reader.ReadUInt32();
+
+            if (version != 1) {
+                return false;
+            }
+
+            unknownEnum = (EnumUnknownEnum) reader.ReadUInt32();
+
+            var numEntries = reader.ReadUInt32();
+            if (numEntries != 1) {
+                Debug.LogError($"Technically, the CDT file spec supports more than one entry ({name} has {numEntries}), but FLTK doesnt right now.");
+                return false;
+            }
+
+            var alwaysZero = reader.ReadUInt32();
+
+            var vertexCount = reader.ReadUInt32();
+            for (int i = 0; i < vertexCount; i++) {
+                var x = reader.ReadSingle();
+                var y = reader.ReadSingle();
+                var z = reader.ReadSingle();
+
+                verticies.Add(new Vector3(x, y, z));
+            }
+
+            var triangleCount = reader.ReadUInt32();
+            for (int i = 0; i < triangleCount; i++) {
+                indices.Add(reader.ReadUInt16());
+                indices.Add(reader.ReadUInt16());
+                indices.Add(reader.ReadUInt16());
+            }
+
+            colliderMesh = new Mesh();
+            colliderMesh.SetVertices(verticies);
+            colliderMesh.SetIndices(indices, MeshTopology.Triangles, 0);
+
+            // TODO: possible future, read what ever bullet physics data goes right here
+
+            return true;
+        }
+    }
+}

--- a/Editor/FileTypes/CdtFile.cs.meta
+++ b/Editor/FileTypes/CdtFile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8d40516bbeb0744db6d9588f43f788f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Importers/CdtImporter.cs
+++ b/Editor/Importers/CdtImporter.cs
@@ -20,7 +20,7 @@ namespace ForgeLightToolkit.Editor.Importers {
 
             ctx.AddObjectToAsset("cdt", cdtFile);
             ctx.SetMainObject(cdtFile);
-            ctx.AddObjectToAsset("ColliderMesh", cdtFile.colliderMesh);
+            ctx.AddObjectToAsset("collider", cdtFile.colliderMesh);
         }
     }
 }

--- a/Editor/Importers/CdtImporter.cs
+++ b/Editor/Importers/CdtImporter.cs
@@ -1,0 +1,26 @@
+using ForgeLightToolkit.Editor.FileTypes;
+using UnityEngine;
+using UnityEditor.AssetImporters;
+
+namespace ForgeLightToolkit.Editor.Importers {
+    [ScriptedImporter(1, "cdt")]
+    public class CdtImporter : ScriptedImporter {
+        public override void OnImportAsset(AssetImportContext ctx) {
+            if (string.IsNullOrEmpty(ctx.assetPath)) {
+                ctx.LogImportError($"Invalid asset path. ({ctx.assetPath})");
+                return;
+            }
+
+            var cdtFile = ScriptableObject.CreateInstance<CdtFile>();
+
+            if (!cdtFile.Load(ctx.assetPath)) {
+                ctx.LogImportError($"Failed to load cdt file. ({ctx.assetPath})");
+                return;
+            }
+
+            ctx.AddObjectToAsset("cdt", cdtFile);
+            ctx.SetMainObject(cdtFile);
+            ctx.AddObjectToAsset("ColliderMesh", cdtFile.colliderMesh);
+        }
+    }
+}

--- a/Editor/Importers/CdtImporter.cs.meta
+++ b/Editor/Importers/CdtImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 761ffe108092997408340435319c3f6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -17,19 +17,33 @@ namespace ForgeLightToolkit.Editor {
         private const int HorizontalSpace = 15;
         private const int HorizontalTabbedSpace = 25;
 
+        [SerializeField]
         private string worldName = "";
+        [NonSerialized]
         private string adrName = "";
+        [SerializeField]
         private string assetsPath = "Assets/ExtractedPacks";
+        [SerializeField]
         private string prefabSavePath = "Assets/Prefabs/Objects";
+        [SerializeField]
         private string materialsSavePath = "Assets/Materials";
+        [SerializeField]
         private string terrainMaterialsSavePath = "Assets/TerrainMaterials";
+        [SerializeField]
         private string worldPrefabSavePath = "Assets/Prefabs/Worlds";
 
+        [SerializeField]
         private bool fastMode;
+        [SerializeField]
         private bool overrideTerrainMaterials;
+        [SerializeField]
         private bool overrideWorldPrefabsAndMats;
 
+        [NonSerialized]
         private readonly HashSet<string> objectsAlreadyProcessed = new();
+
+        private SerializedObject so;
+        private SerializedObject SObject => so ??= new(this);
 
         [MenuItem("ForgeLight/Load World")]
         public static void ShowWindow() {
@@ -55,7 +69,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            assetsPath = EditorGUILayout.TextField(assetsPath);
+            EditorGUILayout.PropertyField(SObject.FindProperty("assetsPath"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -75,7 +89,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            prefabSavePath = EditorGUILayout.TextField(prefabSavePath);
+            EditorGUILayout.PropertyField(SObject.FindProperty("prefabSavePath"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -95,7 +109,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            worldPrefabSavePath = EditorGUILayout.TextField(worldPrefabSavePath);
+            EditorGUILayout.PropertyField(SObject.FindProperty("worldPrefabSavePath"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -115,7 +129,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            terrainMaterialsSavePath = EditorGUILayout.TextField(terrainMaterialsSavePath);
+            EditorGUILayout.PropertyField(SObject.FindProperty("terrainMaterialsSavePath"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -135,7 +149,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            materialsSavePath = EditorGUILayout.TextField(materialsSavePath);
+            EditorGUILayout.PropertyField(SObject.FindProperty("materialsSavePath"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -155,7 +169,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            worldName = EditorGUILayout.TextField(worldName);
+            EditorGUILayout.PropertyField(SObject.FindProperty("worldName"), new GUIContent());
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -172,20 +186,24 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalTabbedSpace);
-            fastMode = GUILayout.Toggle(fastMode, new GUIContent("Fast Mode", "Loads directly from all original pack assets and skips saving any materials or prefabs"));
+            SObject.FindProperty("fastMode").boolValue = GUILayout.Toggle(fastMode, new GUIContent("Fast Mode", "Loads directly from all original pack assets and skips saving any materials or prefabs"));
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalTabbedSpace);
-            overrideTerrainMaterials = GUILayout.Toggle(overrideTerrainMaterials, new GUIContent("Override Terrain Materials", "Allows for reprocessing of terrain materials while maintaining all existing object prefabs and materials"));
+            SObject.FindProperty("overrideTerrainMaterials").boolValue = GUILayout.Toggle(overrideTerrainMaterials, new GUIContent("Override Terrain Materials", "Allows for reprocessing of terrain materials while maintaining all existing object prefabs and materials"));
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalTabbedSpace);
-            overrideWorldPrefabsAndMats = GUILayout.Toggle(overrideWorldPrefabsAndMats, new GUIContent("Override World Object Prefabs And Materials", "Reprocesses all objects and prefabs in the world"));
+            SObject.FindProperty("overrideWorldPrefabsAndMats").boolValue = GUILayout.Toggle(overrideWorldPrefabsAndMats, new GUIContent("Override World Object Prefabs And Materials", "Reprocesses all objects and prefabs in the world"));
             GUILayout.EndHorizontal();
+
+            if (SObject.hasModifiedProperties) {
+                SObject.ApplyModifiedPropertiesWithoutUndo();
+            }
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalTabbedSpace);
@@ -201,7 +219,7 @@ namespace ForgeLightToolkit.Editor {
 
                     var gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(gzneFileAssetPath);
 
-                    if (gzneFile is null) {
+                    if (gzneFile == null) {
                         continue;
                     }
 
@@ -234,7 +252,7 @@ namespace ForgeLightToolkit.Editor {
 
                     var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFileAssetPath);
 
-                    if (adrFile is null) {
+                    if (adrFile == null) {
                         continue;
                     }
 
@@ -288,18 +306,18 @@ namespace ForgeLightToolkit.Editor {
         private void LoadWorld(string worldName) {
             GzneFile gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(Path.Combine(assetsPath, $"{worldName}.gzne"));
 
-            if (gzneFile is null) {
+            if (gzneFile == null) {
                 return;
             }
 
             GameObject loadedWorldObject = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(worldPrefabSavePath, $"World_{worldName}.prefab"));
-            if (loadedWorldObject is not null && !overrideWorldPrefabsAndMats && !fastMode) {
+            if (loadedWorldObject != null && !overrideWorldPrefabsAndMats && !fastMode) {
                 PrefabUtility.InstantiatePrefab(loadedWorldObject);
                 return;
             }
-            GameObject worldObject = new GameObject($"World_{worldName}");
+            GameObject worldObject = new($"World_{worldName}");
 
-            Dictionary<int, RuntimeObject> loadedRuntimeObjects = new Dictionary<int, RuntimeObject>();
+            Dictionary<int, RuntimeObject> loadedRuntimeObjects = new();
 
             for (var x = gzneFile.StartX; x < gzneFile.WorldSize; x += gzneFile.TilePerChunkAxis) {
                 for (var y = gzneFile.StartY; y < gzneFile.WorldSize; y += gzneFile.TilePerChunkAxis) {
@@ -309,7 +327,7 @@ namespace ForgeLightToolkit.Editor {
 
                     var gcnkFile = AssetDatabase.LoadAssetAtPath<GcnkFile>(gcnkFilePath);
 
-                    if (gcnkFile is null) {
+                    if (gcnkFile == null) {
                         continue;
                     }
 
@@ -338,16 +356,16 @@ namespace ForgeLightToolkit.Editor {
                                 name = $"Tile {tile.Index}"
                             };
 
-                            if (loadedChunkMaterial is not null && !overrideTerrainMaterials && !fastMode) {
+                            if (loadedChunkMaterial != null && !overrideTerrainMaterials && !fastMode) {
                                 chunkMaterial = loadedChunkMaterial;
                                 chunkMaterials[tile.Index] = chunkMaterial;
                                 continue;
                             }
-                            if (gck2File is not null) {
+                            if (gck2File != null) {
                                 chunkMaterial.mainTexture = gck2File.Texture;
                             }
 
-                            if (gcnkFile.DetailMask is not null) {
+                            if (gcnkFile.DetailMask != null) {
                                 chunkMaterial.SetTexture("_DetailMaskMap", gcnkFile.DetailMask);
                             }
 
@@ -392,7 +410,7 @@ namespace ForgeLightToolkit.Editor {
 
                                 var agrFile = AssetDatabase.LoadAssetAtPath<AgrFile>(agrFilePath);
 
-                                if (agrFile is null) {
+                                if (agrFile == null) {
                                     Debug.LogError($"Failed to load Agr. {agrFilePath}");
                                     continue;
                                 }
@@ -432,7 +450,7 @@ namespace ForgeLightToolkit.Editor {
             var adrFilePath = Path.Combine(assetsPath, adrFileName);
             var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFilePath);
             var existingPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(prefabSavePath, Path.ChangeExtension(adrFileName, "prefab")));
-            if (existingPrefab is not null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !fastMode) {
+            if (existingPrefab != null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !fastMode) {
                 GameObject loadedObject = PrefabUtility.InstantiatePrefab(existingPrefab, parentObject.transform) as GameObject;
                 loadedObject.transform.localPosition = position;
                 loadedObject.transform.localScale = Vector3.one * scale;
@@ -450,7 +468,7 @@ namespace ForgeLightToolkit.Editor {
                 return;
             }
 
-            if (adrFile is null) {
+            if (adrFile == null) {
                 Debug.LogError($"Failed to load Adr. {adrFilePath}");
                 return;
             }
@@ -462,7 +480,7 @@ namespace ForgeLightToolkit.Editor {
 
             var dmeFilePath = Path.Combine(assetsPath, adrFile.ModelFileName);
             var dmeFile = AssetDatabase.LoadAssetAtPath<DmeFile>(dmeFilePath);
-            if (dmeFile is null) {
+            if (dmeFile == null) {
                 Debug.LogError($"Failed to load Dme. {dmeFilePath}");
                 return;
             }
@@ -505,7 +523,7 @@ namespace ForgeLightToolkit.Editor {
 
                 var materialShader = Shader.Find($"Custom/{materialDefinition.Name}");
 
-                if (materialShader is null) {
+                if (materialShader == null) {
                     Debug.LogWarning($"Missing Shader \"{materialDefinition.Name}\" for Object \"{adrFileName}\".");
                     continue;
                 }
@@ -561,7 +579,7 @@ namespace ForgeLightToolkit.Editor {
 
                         var texture2d = AssetDatabase.LoadAssetAtPath<Texture2D>(textureFilePath);
 
-                        if (texture2d is null) {
+                        if (texture2d == null) {
                             Debug.LogError($"Failed to find texture. {textureFilePath}");
                             continue;
                         }

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -21,16 +21,26 @@ namespace ForgeLightToolkit.Editor {
         private string worldName = "";
         [NonSerialized]
         private string adrName = "";
+
+        private const string DefaultAssetsPath = "Assets/ExtractedPacks";
         [SerializeField]
-        private string assetsPath = "Assets/ExtractedPacks";
+        private string assetsPath = DefaultAssetsPath;
+
+        private const string DefaultPrefabSavePath = "Assets/Worlds/_Prefabs";
         [SerializeField]
-        private string prefabSavePath = "Assets/Worlds/_Prefabs";
+        private string prefabSavePath = DefaultPrefabSavePath;
+
+        private const string DefaultMaterialsSavePath = "Assets/Worlds/_Materials";
         [SerializeField]
-        private string materialsSavePath = "Assets/Worlds/_Materials";
+        private string materialsSavePath = DefaultMaterialsSavePath;
+
+        private const string DefaultTerrainMaterialsSavePath = "Assets/Worlds/_Materials";
         [SerializeField]
-        private string terrainMaterialsSavePath = "Assets/Worlds/_Materials";
+        private string terrainMaterialsSavePath = DefaultTerrainMaterialsSavePath;
+
+        private const string DefaultWorldPrefabSavePath = "Assets/Worlds/_Prefabs";
         [SerializeField]
-        private string worldPrefabSavePath = "Assets/Worlds/_Prefabs";
+        private string worldPrefabSavePath = DefaultWorldPrefabSavePath;
 
         [SerializeField]
         private bool fastMode;
@@ -63,7 +73,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            GUILayout.Label("Example: Assets/ForgeLight/CloneWarsAdventures", EditorStyles.miniBoldLabel);
+            GUILayout.Label($"Example: {DefaultAssetsPath}", EditorStyles.miniBoldLabel);
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -83,7 +93,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            GUILayout.Label("Example: Assets/Prefabs/Objects", EditorStyles.miniBoldLabel);
+            GUILayout.Label($"Example: {DefaultPrefabSavePath}", EditorStyles.miniBoldLabel);
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -103,7 +113,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            GUILayout.Label("Example: Assets/Prefabs/Worlds", EditorStyles.miniBoldLabel);
+            GUILayout.Label($"Example: {DefaultWorldPrefabSavePath}", EditorStyles.miniBoldLabel);
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -123,7 +133,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            GUILayout.Label("Example: Assets/TerrainMaterials", EditorStyles.miniBoldLabel);
+            GUILayout.Label($"Example: {DefaultTerrainMaterialsSavePath}", EditorStyles.miniBoldLabel);
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
@@ -143,7 +153,7 @@ namespace ForgeLightToolkit.Editor {
 
             GUILayout.BeginHorizontal();
             GUILayout.Space(HorizontalSpace);
-            GUILayout.Label("Example: Assets/Materials", EditorStyles.miniBoldLabel);
+            GUILayout.Label($"Example: {DefaultMaterialsSavePath}", EditorStyles.miniBoldLabel);
             GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -24,13 +24,13 @@ namespace ForgeLightToolkit.Editor {
         [SerializeField]
         private string assetsPath = "Assets/ExtractedPacks";
         [SerializeField]
-        private string prefabSavePath = "Assets/Prefabs/Objects";
+        private string prefabSavePath = "Assets/Worlds/_Prefabs";
         [SerializeField]
-        private string materialsSavePath = "Assets/Materials";
+        private string materialsSavePath = "Assets/Worlds/_Materials";
         [SerializeField]
-        private string terrainMaterialsSavePath = "Assets/TerrainMaterials";
+        private string terrainMaterialsSavePath = "Assets/Worlds/_Materials";
         [SerializeField]
-        private string worldPrefabSavePath = "Assets/Prefabs/Worlds";
+        private string worldPrefabSavePath = "Assets/Worlds/_Prefabs";
 
         [SerializeField]
         private bool fastMode;

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -214,16 +214,24 @@ namespace ForgeLightToolkit.Editor {
 
                 objectsAlreadyProcessed.Clear();
 
-                foreach (var gzneFileAssetGuid in gzneFileAssetGuids) {
-                    var gzneFileAssetPath = AssetDatabase.GUIDToAssetPath(gzneFileAssetGuid);
+                try {
+                    AssetDatabase.StartAssetEditing();
+                    foreach (var gzneFileAssetGuid in gzneFileAssetGuids) {
+                        var gzneFileAssetPath = AssetDatabase.GUIDToAssetPath(gzneFileAssetGuid);
 
-                    var gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(gzneFileAssetPath);
+                        var gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(gzneFileAssetPath);
 
-                    if (gzneFile == null) {
-                        continue;
+                        if (gzneFile == null) {
+                            continue;
+                        }
+
+                        LoadWorld(gzneFile.name);
                     }
-
-                    LoadWorld(gzneFile.name);
+                } catch (Exception e) {
+                    Debug.LogError($"Caught Exception when trying to import world(s) {worldName}");
+                    Debug.LogException(e);
+                } finally {
+                    AssetDatabase.StopAssetEditing();
                 }
             }
             GUILayout.EndHorizontal();
@@ -247,17 +255,26 @@ namespace ForgeLightToolkit.Editor {
 
                 objectsAlreadyProcessed.Clear();
 
-                foreach (var adrFileAssetGuid in adrFileAssetGuids) {
-                    var adrFileAssetPath = AssetDatabase.GUIDToAssetPath(adrFileAssetGuid);
+                try {
+                    AssetDatabase.StartAssetEditing();
+                    foreach (var adrFileAssetGuid in adrFileAssetGuids) {
+                        var adrFileAssetPath = AssetDatabase.GUIDToAssetPath(adrFileAssetGuid);
 
-                    var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFileAssetPath);
+                        var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFileAssetPath);
 
-                    if (adrFile == null) {
-                        continue;
+                        if (adrFile == null) {
+                            continue;
+                        }
+
+                        LoadAdrFile(adrFile.name + ".adr", null, new Vector4(0, 0, 0, 0), 1.0f, new Vector4(0, 0, 0, 0));
                     }
-
-                    LoadAdrFile(adrFile.name + ".adr", null, new Vector4(0, 0, 0, 0), 1.0f, new Vector4(0, 0, 0, 0));
+                } catch (Exception e) {
+                    Debug.LogError($"Caught Exception when trying to import adr file(s) {adrName}");
+                    Debug.LogException(e);
+                } finally {
+                    AssetDatabase.StopAssetEditing();
                 }
+
             }
             GUILayout.EndHorizontal();
             GUILayout.EndArea();
@@ -459,11 +476,11 @@ namespace ForgeLightToolkit.Editor {
                 if (!loadedObject.TryGetComponent<ForgelightObject>(out var forgelightObject)) {
                     Debug.LogWarning($"Prefab for {adrFileName} was missing the ForgelightObject component. Adding a new instance");
                     forgelightObject = loadedObject.AddComponent<ForgelightObject>();
-                    forgelightObject.AdrFileName = adrFileName;
+                    forgelightObject.adrFileName = adrFileName;
                 }
 
                 // Runtime instance IDs of objects shouldnt be saved in the prefab, which means each instantiation needs it's id
-                forgelightObject.RuntimeObjectId = runtimeId;
+                forgelightObject.runtimeObjectId = runtimeId;
 
                 return;
             }
@@ -496,7 +513,11 @@ namespace ForgeLightToolkit.Editor {
 
             // add the runtime data for this object
             var flo = runtimeObject.AddComponent<ForgelightObject>();
-            flo.AdrFileName = adrFileName;
+            flo.adrFileName = adrFileName;
+
+            if (adrFile.collisionFile != null) {
+                AddColliderToObject(runtimeObject, adrFile.collisionFile);
+            }
 
             foreach (var meshEntry in dmeFile.Meshes) {
                 var meshObject = new GameObject() {
@@ -611,12 +632,111 @@ namespace ForgeLightToolkit.Editor {
             }
 
             // only do this after the prefab has been saved, Runtime instance IDs of objects shouldnt be saved in that
-            flo.RuntimeObjectId = runtimeId;
+            flo.runtimeObjectId = runtimeId;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LineNumber([CallerLineNumber] int lineNumber = 0) {
             return lineNumber;
+        }
+
+        public static void AddColliderToObject(GameObject go, string collisionFile) {
+            var collisionFileNoExt = Path.GetFileNameWithoutExtension(collisionFile);
+            var guids = AssetDatabase.FindAssets($"t:cdtFile {collisionFileNoExt}");
+            if (guids == null || guids.Length == 0) {
+                Debug.LogError($"No collision file exists for {collisionFile}, not adding a collider to {go.name}");
+                return;
+            }
+
+            if (guids.Length > 1) {
+                Debug.LogError($"More than one ({guids.Length}) collision file exists for {collisionFile}, not adding a collider to {go.name}");
+                return;
+            }
+
+            var cdtFilePath = AssetDatabase.GUIDToAssetPath(guids[0]);
+            var cdtFile = AssetDatabase.LoadAssetAtPath<CdtFile>(cdtFilePath);
+
+            var meshCollider = go.AddComponent<MeshCollider>();
+            meshCollider.sharedMesh = cdtFile.colliderMesh;
+        }
+
+        [MenuItem("ForgeLight/Ensure Preafabs Have Correct ADR File Name")]
+        public static void EnsurePreafabsHaveCorrectName() {
+            var all = Directory.EnumerateFiles("Assets/Worlds", "*.prefab", SearchOption.AllDirectories);
+
+            try {
+                AssetDatabase.StartAssetEditing();
+                foreach (var path in all) {
+                    var prefabName = Path.GetFileNameWithoutExtension(path);
+
+                    using var prefabContext = new PrefabUtility.EditPrefabContentsScope(path);
+                    var go = prefabContext.prefabContentsRoot;
+
+                    if (go.TryGetComponent<ForgelightObject>(out var flo)) {
+                        var adrPaths = AssetDatabase.FindAssets($"t:adrFile {Path.GetFileNameWithoutExtension(flo.adrFileName)}")
+                            .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                            .Where(path => Path.GetFileNameWithoutExtension(path) == prefabName)
+                            .ToList();
+
+                        if (adrPaths.Count == 1) {
+                            flo.adrFileName = $"{prefabName}.adr";
+                        } else {
+                            Debug.LogWarning($"{path} found {string.Join(',', adrPaths)} as matches");
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Debug.LogError("Failed to apply colliders");
+                Debug.LogException(e);
+            } finally {
+                AssetDatabase.StopAssetEditing();
+            }
+        }
+
+        [MenuItem("ForgeLight/Add Colliders to ADR Prefabs")]
+        public static void AddCollidersToObjectPrefabs() {
+            var all = Directory.EnumerateFiles("Assets/Worlds", "*.prefab", SearchOption.AllDirectories);
+
+            try {
+                AssetDatabase.StartAssetEditing();
+                foreach (var path in all) {
+                    var prefabName = Path.GetFileNameWithoutExtension(path);
+
+                    using var prefabContext = new PrefabUtility.EditPrefabContentsScope(path);
+                    var go = prefabContext.prefabContentsRoot;
+
+                    if (go.TryGetComponent<ForgelightObject>(out var flo) && !go.TryGetComponent<MeshCollider>(out var _)) {
+                        var adrPaths = AssetDatabase.FindAssets($"t:adrFile {Path.GetFileNameWithoutExtension(flo.adrFileName)}")
+                            .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                            .Where(path => Path.GetFileNameWithoutExtension(path) == prefabName)
+                            .ToList();
+
+                        if (adrPaths.Count == 1) {
+                            var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrPaths[0]);
+
+                            var cdtFileName = adrFile.collisionFile;
+                            var cdtGuids = AssetDatabase.FindAssets($"t:cdtFile {Path.GetFileNameWithoutExtension(cdtFileName)}")
+                                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                                .ToList();
+
+                            if (cdtGuids.Count == 1) {
+                                var cdtFile = AssetDatabase.LoadAssetAtPath<CdtFile>(cdtGuids[0]);
+                                var mc = go.AddComponent<MeshCollider>();
+                                mc.sharedMesh = cdtFile.colliderMesh;
+                            } else {
+                                Debug.LogWarning($"{path} found {string.Join(',', adrPaths)} as cdt matches");
+                            }
+                        } else {
+                            Debug.LogWarning($"{path} found {string.Join(',', adrPaths)} as adr matches");
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Debug.LogError("Failed to apply colliders");
+                Debug.LogException(e);
+            } finally {
+                AssetDatabase.StopAssetEditing();
+            }
         }
     }
 }

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -1,18 +1,22 @@
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-
-using UnityEditor;
-using UnityEngine;
 using ForgeLightToolkit.Editor.FileTypes;
 using ForgeLightToolkit.Editor.FileTypes.Dma;
 using ForgeLightToolkit.Editor.FileTypes.Gcnk;
 using ForgeLightToolkit.Runtime;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using UnityEditor;
+using UnityEngine;
 using UnityEngine.Rendering;
 
 namespace ForgeLightToolkit.Editor {
     public class LoadWorldWindow : EditorWindow {
+        private const int VerticalSpace = 15;
+        private const int HorizontalSpace = 15;
+        private const int HorizontalTabbedSpace = 25;
+
         private string worldName = "";
         private string adrName = "";
         private string assetsPath = "Assets/ExtractedPacks";
@@ -21,11 +25,11 @@ namespace ForgeLightToolkit.Editor {
         private string terrainMaterialsSavePath = "Assets/TerrainMaterials";
         private string worldPrefabSavePath = "Assets/Prefabs/Worlds";
 
-        private bool _fastMode = false;
-        private bool _overrideTerrainMaterials;
-        private bool _overrideWorldPrefabsAndMats;
+        private bool fastMode;
+        private bool overrideTerrainMaterials;
+        private bool overrideWorldPrefabsAndMats;
 
-        private HashSet<string> objectsAlreadyProcessed;
+        private readonly HashSet<string> objectsAlreadyProcessed = new();
 
         [MenuItem("ForgeLight/Load World")]
         public static void ShowWindow() {
@@ -35,160 +39,162 @@ namespace ForgeLightToolkit.Editor {
         private void OnGUI() {
             GUILayout.BeginArea(new Rect(0, 0, Screen.width / EditorGUIUtility.pixelsPerPoint, Screen.height / EditorGUIUtility.pixelsPerPoint));
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Assets Path", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: Assets/ForgeLight/CloneWarsAdventures", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             assetsPath = EditorGUILayout.TextField(assetsPath);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Object Prefab Save Location", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: Assets/Prefabs/Objects", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             prefabSavePath = EditorGUILayout.TextField(prefabSavePath);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("World Prefab Save Location", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: Assets/Prefabs/Worlds", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             worldPrefabSavePath = EditorGUILayout.TextField(worldPrefabSavePath);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Terrain Materials Save Location", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: Assets/TerrainMaterials", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             terrainMaterialsSavePath = EditorGUILayout.TextField(terrainMaterialsSavePath);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Object Materials Save Location", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: Assets/Materials", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             materialsSavePath = EditorGUILayout.TextField(materialsSavePath);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("World Name", EditorStyles.boldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label("Example: JediTemple", EditorStyles.miniBoldLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             worldName = EditorGUILayout.TextField(worldName);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
-            GUILayout.Space(15);
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.Label(
                 "Please read the tooltips on the following boxes " +
                 "to ensure you know what you are doing before " +
                 "you run with any of the options selected.", EditorStyles.wordWrappedLabel);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(25);
-            _fastMode = GUILayout.Toggle(_fastMode, new GUIContent("Fast Mode", "Loads directly from all original pack assets and skips saving any materials or prefabs"));
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalTabbedSpace);
+            fastMode = GUILayout.Toggle(fastMode, new GUIContent("Fast Mode", "Loads directly from all original pack assets and skips saving any materials or prefabs"));
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(25);
-            _overrideTerrainMaterials = GUILayout.Toggle(_overrideTerrainMaterials, new GUIContent("Override Terrain Materials", "Allows for reprocessing of terrain materials while maintaining all existing object prefabs and materials"));
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalTabbedSpace);
+            overrideTerrainMaterials = GUILayout.Toggle(overrideTerrainMaterials, new GUIContent("Override Terrain Materials", "Allows for reprocessing of terrain materials while maintaining all existing object prefabs and materials"));
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(25);
-            _overrideWorldPrefabsAndMats = GUILayout.Toggle(_overrideWorldPrefabsAndMats, new GUIContent("Override World Object Prefabs And Materials", "Reprocesses all objects and prefabs in the world"));
+            GUILayout.Space(HorizontalTabbedSpace);
+            overrideWorldPrefabsAndMats = GUILayout.Toggle(overrideWorldPrefabsAndMats, new GUIContent("Override World Object Prefabs And Materials", "Reprocesses all objects and prefabs in the world"));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(25);
-            if (GUILayout.Button("Load World(s)", GUILayout.ExpandWidth(false)) && !string.IsNullOrEmpty(assetsPath) && !string.IsNullOrEmpty(prefabSavePath) && !string.IsNullOrEmpty(materialsSavePath)) {
+            GUILayout.Space(HorizontalTabbedSpace);
+            if (GUILayout.Button("Load World(s)", GUILayout.ExpandWidth(false)) && buttonClickValid()) {
                 var gzneFileAssetGuids = AssetDatabase.FindAssets($"glob:\"{assetsPath}/{worldName}.gzne\"");
 
-                objectsAlreadyProcessed = new HashSet<string>();
+                ensureDirectoriesExist();
+
+                objectsAlreadyProcessed.Clear();
 
                 foreach (var gzneFileAssetGuid in gzneFileAssetGuids) {
                     var gzneFileAssetPath = AssetDatabase.GUIDToAssetPath(gzneFileAssetGuid);
@@ -203,21 +209,25 @@ namespace ForgeLightToolkit.Editor {
                 }
             }
             GUILayout.EndHorizontal();
-            GUILayout.Space(15);
+
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             adrName = EditorGUILayout.TextField(adrName);
-            GUILayout.Space(15);
+            GUILayout.Space(HorizontalSpace);
             GUILayout.EndHorizontal();
-            GUILayout.Space(15);
+
+            GUILayout.Space(VerticalSpace);
 
             GUILayout.BeginHorizontal();
-            GUILayout.Space(25);
-            if (GUILayout.Button("Load Adr(s)", GUILayout.ExpandWidth(false)) && !string.IsNullOrEmpty(assetsPath) && !string.IsNullOrEmpty(prefabSavePath) && !string.IsNullOrEmpty(materialsSavePath)) {
+            GUILayout.Space(HorizontalTabbedSpace);
+            if (GUILayout.Button("Load Adr(s)", GUILayout.ExpandWidth(false)) && buttonClickValid()) {
                 var adrFileAssetGuids = AssetDatabase.FindAssets($"glob:\"{assetsPath}/{adrName}.adr\"");
 
-                objectsAlreadyProcessed = new HashSet<string>();
+                ensureDirectoriesExist();
+
+                objectsAlreadyProcessed.Clear();
 
                 foreach (var adrFileAssetGuid in adrFileAssetGuids) {
                     var adrFileAssetPath = AssetDatabase.GUIDToAssetPath(adrFileAssetGuid);
@@ -235,6 +245,45 @@ namespace ForgeLightToolkit.Editor {
             GUILayout.EndArea();
         }
 
+        private bool buttonClickValid() {
+            bool condition = !string.IsNullOrEmpty(assetsPath) && !string.IsNullOrEmpty(prefabSavePath) && !string.IsNullOrEmpty(materialsSavePath);
+
+            if (!condition) {
+                List<string> badInputs = new();
+                if (string.IsNullOrEmpty(assetsPath)) {
+                    badInputs.Add("Assets Path");
+                }
+                if (string.IsNullOrEmpty(prefabSavePath)) {
+                    badInputs.Add("Prefab Save Path");
+                }
+                if (!string.IsNullOrEmpty(materialsSavePath)) {
+                    badInputs.Add($"Materials Save Path");
+                }
+
+                Debug.LogError($"LWW: Missing Required Inputs: {string.Join(", ", badInputs)}");
+            }
+
+            return condition;
+        }
+
+        private void ensureDirectoriesExist() {
+            if (!Directory.Exists(assetsPath)) {
+                Directory.CreateDirectory(assetsPath);
+            }
+            if (!Directory.Exists(prefabSavePath)) {
+                Directory.CreateDirectory(prefabSavePath);
+            }
+            if (!Directory.Exists(materialsSavePath)) {
+                Directory.CreateDirectory(materialsSavePath);
+            }
+            if (!Directory.Exists(terrainMaterialsSavePath)) {
+                Directory.CreateDirectory(terrainMaterialsSavePath);
+            }
+            if (!Directory.Exists(worldPrefabSavePath)) {
+                Directory.CreateDirectory(worldPrefabSavePath);
+            }
+        }
+
         // ReSharper disable Unity.PerformanceAnalysis
         private void LoadWorld(string worldName) {
             GzneFile gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(Path.Combine(assetsPath, $"{worldName}.gzne"));
@@ -244,7 +293,7 @@ namespace ForgeLightToolkit.Editor {
             }
 
             GameObject loadedWorldObject = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(worldPrefabSavePath, $"World_{worldName}.prefab"));
-            if (loadedWorldObject is not null && !_overrideWorldPrefabsAndMats && !_fastMode) {
+            if (loadedWorldObject is not null && !overrideWorldPrefabsAndMats && !fastMode) {
                 PrefabUtility.InstantiatePrefab(loadedWorldObject);
                 return;
             }
@@ -289,7 +338,7 @@ namespace ForgeLightToolkit.Editor {
                                 name = $"Tile {tile.Index}"
                             };
 
-                            if (loadedChunkMaterial is not null && !_overrideTerrainMaterials && !_fastMode) {
+                            if (loadedChunkMaterial is not null && !overrideTerrainMaterials && !fastMode) {
                                 chunkMaterial = loadedChunkMaterial;
                                 chunkMaterials[tile.Index] = chunkMaterial;
                                 continue;
@@ -314,7 +363,7 @@ namespace ForgeLightToolkit.Editor {
 
                                 chunkMaterial.SetTexture($"_DetailColorMap{i}", ecoDataTexture2d);
                             }
-                            if (!_fastMode) {
+                            if (!fastMode) {
                                 AssetDatabase.CreateAsset(chunkMaterial, Path.Combine(terrainMaterialsSavePath, gcnkFile.name + "_" + tile.Index.ToString() + ".mat"));
                             }
                             chunkMaterials[tile.Index] = chunkMaterial;
@@ -373,7 +422,7 @@ namespace ForgeLightToolkit.Editor {
                 }
             }
             worldObject.transform.localScale = new Vector3(1, 1, -1);
-            if (!_fastMode) {
+            if (!fastMode) {
                 PrefabUtility.SaveAsPrefabAssetAndConnect(worldObject, Path.Combine(worldPrefabSavePath, worldObject.name + ".prefab"), InteractionMode.AutomatedAction);
             }
         }
@@ -383,7 +432,7 @@ namespace ForgeLightToolkit.Editor {
             var adrFilePath = Path.Combine(assetsPath, adrFileName);
             var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFilePath);
             var existingPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(prefabSavePath, Path.ChangeExtension(adrFileName, "prefab")));
-            if (existingPrefab is not null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !_fastMode) {
+            if (existingPrefab is not null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !fastMode) {
                 GameObject loadedObject = PrefabUtility.InstantiatePrefab(existingPrefab, parentObject.transform) as GameObject;
                 loadedObject.transform.localPosition = position;
                 loadedObject.transform.localScale = Vector3.one * scale;
@@ -467,7 +516,7 @@ namespace ForgeLightToolkit.Editor {
                 Material loadedMat = null;
 
                 foreach (var parameterEntry in materialEntry.ParameterEntries) {
-                    if (parameterEntry.Class == D3DXPARAMETER_CLASS.D3DXPC_OBJECT && !_fastMode) {
+                    if (parameterEntry.Class == D3DXPARAMETER_CLASS.D3DXPC_OBJECT && !fastMode) {
                         var textureName = dmeFile.DmaFile.Textures.FirstOrDefault(x => JenkinsHelper.JenkinsOneAtATimeHash(x.ToUpper()) == parameterEntry.Object);
                         textureName ??= "SOMETHING_HAS_GONE_WRONG.mat";
                         matFileName = Path.ChangeExtension(materialDefinition.Name + "_" + textureName.Split(".")[0] + adrFileName, "mat");
@@ -527,7 +576,7 @@ namespace ForgeLightToolkit.Editor {
                 if (matFileName == "") {
                     matFileName = $"See_LoadWorldWindow_Line_{LineNumber()}.mat";
                 }
-                if (!_fastMode) {
+                if (!fastMode) {
                     AssetDatabase.CreateAsset(objectMaterial, Path.Combine(materialsSavePath, matFileName));
                 }
                 meshObject.name = meshEntry.Mesh.name;
@@ -537,7 +586,7 @@ namespace ForgeLightToolkit.Editor {
             }
 
             objectsAlreadyProcessed.Add(runtimeObject.name);
-            if (!_fastMode) {
+            if (!fastMode) {
                 runtimeObject.transform.localScale = Vector3.one;
                 PrefabUtility.SaveAsPrefabAssetAndConnect(runtimeObject, Path.Combine(prefabSavePath, runtimeObject.name + ".prefab"), InteractionMode.AutomatedAction);
                 runtimeObject.transform.localScale = Vector3.one * scale;

--- a/Runtime/ForgelightObject.cs
+++ b/Runtime/ForgelightObject.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 namespace ForgeLightToolkit.Runtime {
     // This class exists to persist the ADR and ID of a Forgelight Object during runetime, but mostly editor time. Removing these pre-build is a pain.
     public class ForgelightObject : MonoBehaviour {
-        public string AdrFileName { get; set; }
-        public int RuntimeObjectId { get; set; }
+        public string adrFileName;
+        public int runtimeObjectId;
     }
 }


### PR DESCRIPTION
- Made the LoadWorldWindow use the serialized object pattern to persist window data for as long as the window is open
- Added support for loading CDT files and applying their colliders to existing and new worlds
- Started working on parsing more data off of the adr files