### PR TITLE
Material file recovery improvements and being able to restore light data

### DIFF
--- a/Editor/FileTypes/Dme/MeshEntry.cs
+++ b/Editor/FileTypes/Dme/MeshEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 using UnityEngine;
@@ -34,10 +34,12 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
                 name = $"{name}_Mesh_{meshIndex}",
             };
 
-            var materialDefinition = MaterialInfo.Instance.MaterialDefinitions.SingleOrDefault(x => x.NameHash == materialEntry.Hash);
+            var materialDefinition = MaterialInfo.Instance?.MaterialDefinitions.SingleOrDefault(x => x.NameHash == materialEntry.Hash);
 
-            if (materialDefinition is null)
+            if (materialDefinition is null) {
+                Debug.LogError("Failed to find material definition.");
                 return false;
+            }
 
             var drawStyle = materialDefinition.DrawStyles.First();
 
@@ -47,7 +49,7 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
                 return false;
             }
 
-            var inputLayout = MaterialInfo.Instance.InputLayouts.SingleOrDefault(x => x.NameHash == drawStyle.InputLayoutHash);
+            var inputLayout = MaterialInfo.Instance?.InputLayouts.SingleOrDefault(x => x.NameHash == drawStyle.InputLayoutHash);
 
             if (inputLayout is null)
             {
@@ -80,7 +82,7 @@ namespace ForgeLightToolkit.Editor.FileTypes.Dme
             }
             else
             {
-                Debug.LogError($"Unimplemented Input Layout Type \"{positionEntry.Type}\" for Normal.");
+                Debug.LogError($"Unimplemented Input Layout Type \"{positionEntry.Type}\" for Position.");
                 return false;
             }
 

--- a/Editor/FileTypes/GcnkFile.cs
+++ b/Editor/FileTypes/GcnkFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;

--- a/Editor/Importers/AdrImporter.cs
+++ b/Editor/Importers/AdrImporter.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor.AssetImporters;
 
 using ForgeLightToolkit.Editor.FileTypes;
@@ -18,14 +18,15 @@ namespace ForgeLightToolkit.Editor.Importers
 
             var adrFile = ScriptableObject.CreateInstance<AdrFile>();
 
+            // Logging the error here allows the ADR file to still be searchable in the asset manager with t:adrFile
+            ctx.AddObjectToAsset("Adr", adrFile);
+            ctx.SetMainObject(adrFile);
+
             if (!adrFile.Load(ctx.assetPath))
             {
                 ctx.LogImportError($"Failed to load adr file. ({ctx.assetPath})");
                 return;
             }
-
-            ctx.AddObjectToAsset("Adr", adrFile);
-            ctx.SetMainObject(adrFile);
         }
     }
 }

--- a/Editor/Importers/DmeImporter.cs
+++ b/Editor/Importers/DmeImporter.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor.AssetImporters;
 
 using ForgeLightToolkit.Editor.FileTypes;
@@ -18,14 +18,14 @@ namespace ForgeLightToolkit.Editor.Importers
 
             var dmeFile = ScriptableObject.CreateInstance<DmeFile>();
 
-            if (!dmeFile.Load(ctx.assetPath))
-            {
+            ctx.AddObjectToAsset("Dme", dmeFile);
+            ctx.SetMainObject(dmeFile);
+
+            // Logging the error here allows the DME file to still be searchable in the asset manager with t:dmeFile
+            if (!dmeFile.Load(ctx.assetPath)) {
                 ctx.LogImportError($"Failed to load dme file. ({ctx.assetPath})");
                 return;
             }
-
-            ctx.AddObjectToAsset("Dme", dmeFile);
-            ctx.SetMainObject(dmeFile);
 
             ctx.AddObjectToAsset("Dma", dmeFile.DmaFile);
 

--- a/Editor/Inspectors.meta
+++ b/Editor/Inspectors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3985a18ffef73484c8e0d224f5291c23
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/ForgelightLightInspector.cs
+++ b/Editor/Inspectors/ForgelightLightInspector.cs
@@ -1,0 +1,72 @@
+using ForgeLightToolkit.Runtime;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace ForgeLightToolkit.Editor.Inspectors {
+    [CustomEditor(typeof(ForgelightLight))]
+    [CanEditMultipleObjects]
+    public class ForgelightLightInspector : UnityEditor.Editor {
+        public VisualTreeAsset Inspector;
+
+        public override VisualElement CreateInspectorGUI() {
+            if (Application.isPlaying) {
+                return new();
+            }
+
+            VisualElement root = new();
+
+            Inspector.CloneTree(root);
+
+            var resetBtnEle = root.Q("reset");
+            if (resetBtnEle is Button resetBtn) {
+                resetBtn.clicked += resetTargettedLights;
+            }
+
+            return root;
+        }
+
+        private void resetTargettedLights() {
+            Dictionary<ForgelightWorld, Dictionary<string, ForgelightLight>> worldMapping = new();
+
+            foreach (var worldTarget in targets) {
+                if (worldTarget is ForgelightLight light) {
+                    var world = light.GetComponentInParent<ForgelightWorld>();
+
+                    if (!worldMapping.TryGetValue(world, out var dict)) {
+                        dict = new();
+                        worldMapping.Add(world, dict);
+                    }
+                    if (dict.ContainsKey(light.uniqueLightId)) {
+                        Debug.LogError($"Multiple ForgelightLight objects have the same id ({light.uniqueLightId}), {light.name} will not be reset", light);
+                    } else {
+                        dict.Add(light.uniqueLightId, light);
+                    }
+                }
+            }
+
+            foreach (var world in worldMapping.Keys) {
+                var worldName = world.worldName;
+                var gzneFile = LoadWorldWindow.FindSingularGzne(worldName);
+                if (gzneFile == null) {
+                    continue;
+                }
+
+                var toResetDict = worldMapping[world];
+                var chunks = LoadWorldWindow.FindTilesForWorld(gzneFile);
+                foreach (var chunk in chunks) {
+                    foreach (var tile in chunk.Tiles) {
+                        for (int i = 0; i < tile.RawLights.Count; i++) {
+                            var rawLight = tile.RawLights[i];
+                            string lightId = ForgelightLight.CreateUniqueLightId(tile.Coords.x, tile.Coords.y, i, rawLight.ColorName);
+                            if (toResetDict.Remove(lightId, out var toUpdate)) {
+                                LoadWorldWindow.SetLightProperties(toUpdate.GetComponent<Light>(), rawLight);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Editor/Inspectors/ForgelightLightInspector.cs.meta
+++ b/Editor/Inspectors/ForgelightLightInspector.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f324a6678159b2b47978a7f6b041c64f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - Inspector: {fileID: 9197481963319205126, guid: 6b5e310f5349ced4696bae04042023cc,
+      type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Inspectors/ForgelightLightUI.uxml
+++ b/Editor/Inspectors/ForgelightLightUI.uxml
@@ -1,0 +1,4 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
+    <ui:Label text="ForgeLight Light" display-tooltip-when-elided="true" />
+    <ui:Button text="Reset Light to Chunk Data" display-tooltip-when-elided="true" name="reset" style="top: 2px;" />
+</ui:UXML>

--- a/Editor/Inspectors/ForgelightLightUI.uxml.meta
+++ b/Editor/Inspectors/ForgelightLightUI.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6b5e310f5349ced4696bae04042023cc
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -331,12 +331,16 @@ namespace ForgeLightToolkit.Editor {
 
         // ReSharper disable Unity.PerformanceAnalysis
         private void LoadWorld(GzneFile gzneFile, string loadedWorldName) {
+            // TODO: is it worth looking into handling upserts?
+
             GameObject loadedWorldObject = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(worldPrefabSavePath, $"World_{loadedWorldName}.prefab"));
             if (loadedWorldObject != null && !overrideWorldPrefabsAndMats && !fastMode) {
                 PrefabUtility.InstantiatePrefab(loadedWorldObject);
                 return;
             }
             GameObject worldObject = new($"World_{loadedWorldName}");
+            var flWorld = worldObject.AddComponent<ForgelightWorld>();
+            flWorld.worldName = loadedWorldName;
 
             Dictionary<int, RuntimeObject> loadedRuntimeObjects = new();
 
@@ -442,7 +446,8 @@ namespace ForgeLightToolkit.Editor {
                             }
                         }
 
-                        foreach (var rawLight in tile.RawLights) {
+                        for (int i = 0; i < tile.RawLights.Count; i++) {
+                            var rawLight = tile.RawLights[i];
                             var lightObject = new GameObject($"Light ({rawLight.Name})") {
                                 transform = {
                                     parent = chunkObject.transform,
@@ -452,19 +457,17 @@ namespace ForgeLightToolkit.Editor {
 
                             Light lightComp = lightObject.AddComponent<Light>();
 
-                            lightComp.range = rawLight.Range;
-                            lightComp.color = rawLight.Color;
-                            lightComp.intensity = rawLight.Intensity;
-                            lightComp.lightmapBakeType = LightmapBakeType.Baked;
+                            SetLightProperties(lightComp, rawLight);
+
+                            // persist this data so that we can reset the light to default via a button in the inspector if we want to
+                            var flLight = lightObject.AddComponent<ForgelightLight>();
+                            flLight.uniqueLightId = ForgelightLight.CreateUniqueLightId(tile.Coords.x, tile.Coords.y, i, rawLight.ColorName);
                         }
                     }
                 }
             }
 
-
-            // assumes that walls havent already been generated, though to be fair, none of this code really handles updates.
-            // Is it worth investing the time to make FLTK do upserts instead of only adds? TBD
-            addWallsToGameObject(worldObject, gzneFile);
+            addWallsToGameObject(flWorld, gzneFile);
 
             worldObject.transform.localScale = new Vector3(1, 1, -1);
             if (!fastMode) {
@@ -476,6 +479,7 @@ namespace ForgeLightToolkit.Editor {
         private void LoadAdrFile(string adrFileName, GameObject parentObject, Vector4 position, float scale, Vector4 rotation, int runtimeId = 0) {
             var adrFilePath = Path.Combine(assetsPath, adrFileName);
             var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFilePath);
+
             var existingPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(prefabSavePath, Path.ChangeExtension(adrFileName, "prefab")));
             if (existingPrefab != null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !fastMode) {
                 GameObject loadedObject = PrefabUtility.InstantiatePrefab(existingPrefab, parentObject.transform) as GameObject;
@@ -766,14 +770,17 @@ namespace ForgeLightToolkit.Editor {
             }
         }
 
-        private static void addWallsToGameObject(GameObject toModify, GzneFile gzneFile) {
+        private static void addWallsToGameObject(ForgelightWorld toModify, GzneFile gzneFile) {
             if (gzneFile.wallMeshes.Count > 0) {
-                var parentGo = new GameObject("InvisibleWalls");
-                parentGo.transform.SetParent(toModify.transform, false);
+                if (toModify.invisibleWallsRoot == null) {
+                    var parentGo = new GameObject("InvisibleWalls");
+                    parentGo.transform.SetParent(toModify.transform, false);
+                    toModify.invisibleWallsRoot = parentGo.transform;
+                }
 
                 foreach (var wallMesh in gzneFile.wallMeshes) {
                     var wallGo = new GameObject(wallMesh.name);
-                    wallGo.transform.SetParent(parentGo.transform, false);
+                    wallGo.transform.SetParent(toModify.invisibleWallsRoot, false);
                     var meshCollide = wallGo.AddComponent<MeshCollider>();
                     meshCollide.sharedMesh = wallMesh;
                 }
@@ -783,6 +790,8 @@ namespace ForgeLightToolkit.Editor {
 
         [MenuItem("ForgeLight/Add Invisible Walls to Current World")]
         public static void AddInvisibleWallsToExistingWorld() {
+            // TODO: do i make this only use ForgelightWorld or do i keep the old way in?
+
             var gameObjects = FindObjectsOfType<GameObject>();
             List<GameObject> found = new();
             foreach (var gameObject in gameObjects) {
@@ -802,15 +811,8 @@ namespace ForgeLightToolkit.Editor {
 
             var foundObject = found[0];
             var worldName = foundObject.name.Replace("World_", "");
-
-            var gzneFileAssetGuids = AssetDatabase.FindAssets($"glob:\"{worldName}.gzne\"");
-
-            if (gzneFileAssetGuids.Length == 0) {
-                Debug.LogError($"Could not find a world file to match calculated world name {worldName}");
-                return;
-            }
-            if (gzneFileAssetGuids.Length > 1) {
-                Debug.LogError($"Found {gzneFileAssetGuids.Length} world files to match calculated world name {worldName}, only expecting one...");
+            var gzneFile = FindSingularGzne(worldName);
+            if (gzneFile == null) {
                 return;
             }
 
@@ -822,19 +824,68 @@ namespace ForgeLightToolkit.Editor {
                 toModify = scope?.prefabContentsRoot;
             }
 
-            var gzneFile = AssetDatabase.LoadAssetAtPath<GzneFile>(AssetDatabase.GUIDToAssetPath(gzneFileAssetGuids[0]));
             // only add the walls if there is not already a game object for it
             var possiblyExistingWallsObj = toModify.transform.Find("InvisibleWalls");
             if (possiblyExistingWallsObj) {
                 Debug.LogWarning("Walls object already exists, if you want to regenerate the walls objects, delete the existing one.", possiblyExistingWallsObj.gameObject);
             } else {
-                addWallsToGameObject(toModify, gzneFile);
+                if (!toModify.TryGetComponent<ForgelightWorld>(out var world)) {
+                    world = toModify.AddComponent<ForgelightWorld>();
+                    world.worldName = worldName;
+                }
+
+                addWallsToGameObject(world, gzneFile);
             }
 
             // be a good citizen to the unity world
             if (scope != null) {
                 scope?.Dispose();
             }
+        }
+
+        public static GzneFile FindSingularGzne(string worldName) {
+            var gzneFileAssetGuids = AssetDatabase.FindAssets($"glob:\"{worldName}.gzne\"");
+
+            if (gzneFileAssetGuids.Length == 0) {
+                Debug.LogError($"Could not find a world file to match calculated world name {worldName}");
+                return null;
+            }
+            if (gzneFileAssetGuids.Length > 1) {
+                Debug.LogError($"Found {gzneFileAssetGuids.Length} world files to match calculated world name {worldName}, only expecting one...");
+                return null;
+            }
+            return AssetDatabase.LoadAssetAtPath<GzneFile>(AssetDatabase.GUIDToAssetPath(gzneFileAssetGuids[0]));
+        }
+
+        public static GcnkFile[] FindTilesForWorld(GzneFile gzneFile) {
+            string worldName = gzneFile.name;
+
+            List<GcnkFile> chunks = new();
+            for (var x = gzneFile.StartX; x < gzneFile.WorldSize; x += gzneFile.TilePerChunkAxis) {
+                for (var y = gzneFile.StartY; y < gzneFile.WorldSize; y += gzneFile.TilePerChunkAxis) {
+                    var chunkFileName = $"{worldName}_{x}_{y}";
+
+                    var gcnkFileAssetPaths = AssetDatabase.FindAssets($"glob:\"{chunkFileName}.gcnk\"").Select(AssetDatabase.GUIDToAssetPath).ToArray();
+                    if (gcnkFileAssetPaths.Length == 0) {
+                        continue;
+                    }
+                    if (gcnkFileAssetPaths.Length > 1) {
+                        Debug.LogError($"Found {gcnkFileAssetPaths.Length} cunk files for {chunkFileName}, only expecting one...\nUsing the first one at {gcnkFileAssetPaths[0]}");
+                    }
+
+                    var chunk = AssetDatabase.LoadAssetAtPath<GcnkFile>(gcnkFileAssetPaths[0]);
+                    chunks.Add(chunk);
+                }
+            }
+
+            return chunks.ToArray();
+        }
+
+        public static void SetLightProperties(Light unityLight, RawLight rawLight) {
+            unityLight.range = rawLight.Range;
+            unityLight.color = rawLight.Color;
+            unityLight.intensity = rawLight.Intensity;
+            unityLight.lightmapBakeType = LightmapBakeType.Baked;
         }
     }
 }

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -636,9 +636,12 @@ namespace ForgeLightToolkit.Editor {
 
             objectsAlreadyProcessed.Add(runtimeObject.name);
             if (!fastMode) {
+                // save the prefab's position as 0,0,0, transformation should only occur when doing placements
+                runtimeObject.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
                 runtimeObject.transform.localScale = Vector3.one;
                 PrefabUtility.SaveAsPrefabAssetAndConnect(runtimeObject, Path.Combine(prefabSavePath, runtimeObject.name + ".prefab"), InteractionMode.AutomatedAction);
                 runtimeObject.transform.localScale = Vector3.one * scale;
+                runtimeObject.transform.SetLocalPositionAndRotation(position, Quaternion.Euler(rotation.y * Mathf.Rad2Deg, rotation.x * Mathf.Rad2Deg, rotation.z * Mathf.Rad2Deg));
             }
 
             // only do this after the prefab has been saved, Runtime instance IDs of objects shouldnt be saved in that

--- a/Editor/MaterialInfo.cs
+++ b/Editor/MaterialInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Xml.Serialization;
 using System.Collections.Generic;
@@ -6,23 +6,19 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
-namespace ForgeLightToolkit.Editor
-{
+namespace ForgeLightToolkit.Editor {
     [XmlRoot("MaterialInfo")]
-    public class MaterialInfo
-    {
-        private MaterialInfo()
-        {
+    public class MaterialInfo {
+        private MaterialInfo() {
         }
 
         public static MaterialInfo Instance => _instance.Value;
 
-        private static readonly Lazy<MaterialInfo> _instance = new(() =>
-        {
+        private static Lazy<MaterialInfo> _instance = new(CreateMaterialInfo);
+        private static MaterialInfo CreateMaterialInfo() {
             var materialInfoData = AssetDatabase.LoadAssetAtPath<TextAsset>("Packages/com.hybr2d.forgelighttoolkit/Editor/Assets/materials_3.xml");
 
-            if (materialInfoData is null)
-            {
+            if (materialInfoData == null) {
                 Debug.LogError("Failed to find materials_3.xml.");
                 return null;
             }
@@ -32,21 +28,31 @@ namespace ForgeLightToolkit.Editor
             var serializer = new XmlSerializer(typeof(MaterialInfo));
 
             return serializer.Deserialize(fileStream) as MaterialInfo;
-        });
+        }
+
+        [MenuItem("ForgeLight/Reload Material Info")]
+        private static void ReloadMaterialInfoInstance() {
+            var materialInfoData = AssetDatabase.LoadAssetAtPath<TextAsset>("Packages/com.hybr2d.forgelighttoolkit/Editor/Assets/materials_3.xml");
+
+            if (materialInfoData == null) {
+                Debug.LogError("Failed to find materials_3.xml at expected location. Consider closing and reopening the Unity Editor.");
+                return;
+            }
+
+            _instance = new(CreateMaterialInfo);
+        }
+
 
         [XmlElement("InputLayout")]
         public List<InputLayout> InputLayouts { get; set; } = null!;
 
-        public class InputLayout
-        {
+        public class InputLayout {
             private string _name = null!;
 
             [XmlAttribute]
-            public string Name
-            {
+            public string Name {
                 get => _name;
-                set
-                {
+                set {
                     _name = value;
                     NameHash = JenkinsHelper.JenkinsOneAtATimeHash(_name);
                 }
@@ -58,8 +64,7 @@ namespace ForgeLightToolkit.Editor
             [XmlElement("Entry")]
             public List<Entry> Entries { get; set; } = null!;
 
-            public class Entry
-            {
+            public class Entry {
                 [XmlAttribute]
                 public int Stream { get; set; }
 
@@ -69,8 +74,7 @@ namespace ForgeLightToolkit.Editor
                 [XmlAttribute]
                 public EntryType Type { get; set; }
 
-                public enum EntryType
-                {
+                public enum EntryType {
                     [XmlEnum("Float1")] Float1,
                     [XmlEnum("Float2")] Float2,
                     [XmlEnum("Float3")] Float3,
@@ -93,8 +97,7 @@ namespace ForgeLightToolkit.Editor
                 [XmlAttribute]
                 public EntryUsage Usage { get; set; }
 
-                public enum EntryUsage
-                {
+                public enum EntryUsage {
                     [XmlEnum("Position")] Position,
                     [XmlEnum("BlendWeight")] BlendWeight,
                     [XmlEnum("BlendIndices")] BlendIndices,
@@ -117,16 +120,13 @@ namespace ForgeLightToolkit.Editor
         [XmlElement("ParameterGroup")]
         public List<ParameterGroup> ParameterGroups { get; set; } = null!;
 
-        public class ParameterGroup
-        {
+        public class ParameterGroup {
             private string _name = null!;
 
             [XmlAttribute]
-            public string Name
-            {
+            public string Name {
                 get => _name;
-                set
-                {
+                set {
                     _name = value;
                     NameHash = JenkinsHelper.JenkinsOneAtATimeHash(_name);
                 }
@@ -138,16 +138,13 @@ namespace ForgeLightToolkit.Editor
             [XmlElement("Parameter")]
             public List<Parameter> Parameters { get; set; } = null!;
 
-            public class Parameter
-            {
+            public class Parameter {
                 private string _name = null!;
 
                 [XmlAttribute]
-                public string Name
-                {
+                public string Name {
                     get => _name;
-                    set
-                    {
+                    set {
                         _name = value;
                         NameHash = JenkinsHelper.JenkinsOneAtATimeHash(_name);
                     }
@@ -159,11 +156,9 @@ namespace ForgeLightToolkit.Editor
                 private string _variable = null!;
 
                 [XmlAttribute]
-                public string Variable
-                {
+                public string Variable {
                     get => _variable;
-                    set
-                    {
+                    set {
                         _variable = value;
                         VariableHash = JenkinsHelper.JenkinsOneAtATimeHash(_variable);
                     }
@@ -175,8 +170,7 @@ namespace ForgeLightToolkit.Editor
                 [XmlAttribute]
                 public ParameterType Type { get; set; }
 
-                public enum ParameterType
-                {
+                public enum ParameterType {
                     [XmlEnum("Int")] Int,
                     [XmlEnum("Float")] Float,
                     [XmlEnum("Float4")] Float4,
@@ -206,16 +200,13 @@ namespace ForgeLightToolkit.Editor
         [XmlElement("MaterialDefinition")]
         public List<MaterialDefinition> MaterialDefinitions { get; set; } = null!;
 
-        public class MaterialDefinition
-        {
+        public class MaterialDefinition {
             private string _name = null!;
 
             [XmlAttribute]
-            public string Name
-            {
+            public string Name {
                 get => _name;
-                set
-                {
+                set {
                     _name = value;
                     NameHash = JenkinsHelper.JenkinsOneAtATimeHash(_name);
                 }
@@ -230,19 +221,16 @@ namespace ForgeLightToolkit.Editor
             [XmlElement("DrawStyle")]
             public List<DrawStyle> DrawStyles { get; set; } = null!;
 
-            public class DrawStyle
-            {
+            public class DrawStyle {
                 [XmlAttribute]
                 public string Name { get; set; } = null!;
 
                 private string _effect = null!;
 
                 [XmlAttribute]
-                public string Effect
-                {
+                public string Effect {
                     get => _effect;
-                    set
-                    {
+                    set {
                         _effect = value;
                         EffectHash = JenkinsHelper.JenkinsOneAtATimeHash(_effect);
                     }
@@ -254,11 +242,9 @@ namespace ForgeLightToolkit.Editor
                 private string _inputLayout = null!;
 
                 [XmlAttribute]
-                public string InputLayout
-                {
+                public string InputLayout {
                     get => _inputLayout;
-                    set
-                    {
+                    set {
                         _inputLayout = value;
                         InputLayoutHash = JenkinsHelper.JenkinsOneAtATimeHash(_inputLayout);
                     }
@@ -271,16 +257,13 @@ namespace ForgeLightToolkit.Editor
             [XmlElement("Property")]
             public List<Property> Properties { get; set; } = null!;
 
-            public class Property
-            {
+            public class Property {
                 private string _name = null!;
 
                 [XmlAttribute]
-                public string Name
-                {
+                public string Name {
                     get => _name;
-                    set
-                    {
+                    set {
                         _name = value;
                         NameHash = JenkinsHelper.JenkinsOneAtATimeHash(_name);
                     }

--- a/Runtime/ForgelightLight.cs
+++ b/Runtime/ForgelightLight.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace ForgeLightToolkit.Runtime {
+    // This class exists to persist the information about a Forgelight Light during runetime, but mostly editor time.
+    // Removing this data pre-build is a pain, so just persist what could be used at runtime in a single object.
+    public class ForgelightLight : MonoBehaviour {
+        public string uniqueLightId;
+
+        public static string CreateUniqueLightId(int tileX, int tileY, int lightIndex, string colorName) {
+            return $"flLight:{tileX}x{tileY}-{lightIndex}_{colorName}";
+        }
+    }
+}

--- a/Runtime/ForgelightLight.cs.meta
+++ b/Runtime/ForgelightLight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5ff6ab81624ddf4eb192dddb1ac9452
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/ForgelightObject.cs
+++ b/Runtime/ForgelightObject.cs
@@ -1,7 +1,8 @@
 using UnityEngine;
 
 namespace ForgeLightToolkit.Runtime {
-    // This class exists to persist the ADR and ID of a Forgelight Object during runetime, but mostly editor time. Removing these pre-build is a pain.
+    // This class exists to persist the ADR and ID of a Forgelight Object during runetime, but mostly editor time.
+    // Removing this data pre-build is a pain, so just persist what could be used at runtime in a single object.
     public class ForgelightObject : MonoBehaviour {
         public string adrFileName;
         public int runtimeObjectId;

--- a/Runtime/ForgelightWorld.cs
+++ b/Runtime/ForgelightWorld.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace ForgeLightToolkit.Runtime {
+    // This class exists to persist the information about a Forgelight world during runetime, but mostly editor time.
+    // Removing this data pre-build is a pain, so just persist what could be used at runtime in a single object.
+    public class ForgelightWorld : MonoBehaviour {
+        public string worldName;
+        public Transform invisibleWallsRoot;
+    }
+}

--- a/Runtime/ForgelightWorld.cs.meta
+++ b/Runtime/ForgelightWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d25f5fa41e5ce9e449d58e355a116ad0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Adds ForgelightWorld and ForgelightLight runtime retention components
- Adds ability to reset one or more lights generated by FLTK to the original world data (needs a new world generation)
- Allows users to manually reset the loading of the materials 3 file