### PR TITLE
v2.6.0: Add IAdrExtender and the ability for FLTK Users to extend ADRs, fix some bugs

### DIFF
--- a/Editor/FileTypes/AdrFile.cs
+++ b/Editor/FileTypes/AdrFile.cs
@@ -68,6 +68,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
 
         public MountData mountData;
 
+        // technically this is actually emitter definition, but in cwa, they only do particles here and not sounds
         public List<ParticleEmitterDefinition> particleEmitterDefinitions = new();
         public List<MaterialMapping> materialMappings = new();
         public List<TextureAlias> textureAliases = new();
@@ -841,6 +842,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
                         sound.effectType = reader.ReadByte();
                         break;
                     case EnumAnimationSoundField.Id:
+                        // TODO: this id is technically a 4 byte field, but CWA only uses 2 of the 4
                         sound.id = reader.ReadUInt16();
                         break;
                     case EnumAnimationSoundField.PlayOnce:
@@ -961,6 +963,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
                         particle.toolName = reader.ReadNullTerminatedString();
                         break;
                     case EnumAnimationParticleField.Id:
+                        // TODO: this id is technically a 4 byte field, but CWA only uses 2 of the 4
                         particle.id = reader.ReadUInt16();
                         break;
                     case EnumAnimationParticleField.TriggerEvents:
@@ -1226,6 +1229,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
                 var definitionType = reader.ReadByte();
                 var definitionSize = reader.ReadCompressedLength();
 
+                // TODO: this is incomplete, there is also supposed to be a 0x04, but CWA does not use it
                 switch (definitionType) {
                     case 2:
                         // TODO: blow up if this doesnt meet expectations
@@ -1509,6 +1513,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
                         effect.effectType = reader.ReadByte();
                         break;
                     case EnumCompositeAnimationEffectField.Id:
+                        // TODO: this id is technically a 4 byte field, but CWA only uses 2 of the 4
                         effect.id = reader.ReadUInt16();
                         break;
                     case EnumCompositeAnimationEffectField.TriggerEvents:
@@ -1804,13 +1809,13 @@ namespace ForgeLightToolkit.Editor.FileTypes {
             public ushort id;
             public bool playOnce;
             public byte loadType;
-            public readonly List<TriggerEvent> events = new();
+            public List<TriggerEvent> events = new();
         }
 
         [Serializable]
         public class AnimationSounds {
             public string animationName;
-            public readonly List<AnimationSoundEntry> sounds = new();
+            public List<AnimationSoundEntry> sounds = new();
         }
 
         [Serializable]
@@ -1818,7 +1823,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
             public string name;
             public string toolName;
             public ushort id;
-            public readonly List<TriggerEvent> events = new();
+            public List<TriggerEvent> events = new();
             public bool playOnce;
             public byte loadType;
         }
@@ -1826,7 +1831,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
         [Serializable]
         public class AnimationParticles {
             public string particleName;
-            public readonly List<AnimationParticleEntry> sounds = new();
+            public List<AnimationParticleEntry> sounds = new();
         }
 
         [Serializable]
@@ -1838,13 +1843,13 @@ namespace ForgeLightToolkit.Editor.FileTypes {
         [Serializable]
         public class AnimationActionPoints {
             public string animationName;
-            public readonly List<AnimationActionPoint> actionPoints = new();
+            public List<AnimationActionPoint> actionPoints = new();
         }
 
         [Serializable]
         public class MountData {
             public string runToIdleAnim;
-            public readonly List<MountSeat> seats = new();
+            public List<MountSeat> seats = new();
         }
 
         [Serializable]
@@ -1852,7 +1857,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
             public string boneName;
             public string animName;
             // TODO: unsure if this is an array, treating it as one for now
-            public readonly List<MountSeatEntrance> entrances = new();
+            public List<MountSeatEntrance> entrances = new();
         }
 
         [Serializable]
@@ -1868,14 +1873,14 @@ namespace ForgeLightToolkit.Editor.FileTypes {
             public string name;
             public string toolName;
             public ushort id;
-            public readonly List<TriggerEvent> events = new();
+            public List<TriggerEvent> events = new();
             public byte loadType;
         }
 
         [Serializable]
         public class CompositeAnimationEffects {
             public string animationName;
-            public readonly List<CompositeAnimationEffect> effects = new();
+            public List<CompositeAnimationEffect> effects = new();
         }
 
         [Serializable]
@@ -1891,7 +1896,7 @@ namespace ForgeLightToolkit.Editor.FileTypes {
         public class LookControl {
             public string name;
             public byte type;
-            public readonly List<Joint> joints = new();
+            public List<Joint> joints = new();
             public string effectorBone;
         }
         #endregion

--- a/Editor/IAdrExtender.cs
+++ b/Editor/IAdrExtender.cs
@@ -1,0 +1,49 @@
+using ForgeLightToolkit.Editor.FileTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace ForgeLightToolkit.Editor {
+    public interface IAdrExtender {
+        private static readonly List<IAdrExtender> extenders = new();
+
+        [InitializeOnLoadMethod]
+        public static void InitExtenders() {
+            extenders.Clear();
+            var iaet = typeof(IAdrExtender);
+
+            HashSet<Type> goodTypes = new();
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
+                foreach (var type in assembly.GetTypes()) {
+                    if (type.GetInterfaces().Contains(iaet)) {
+                        goodTypes.Add(type);
+                    }
+                }
+            }
+
+
+            foreach (var type in goodTypes) {
+                extenders.Add((IAdrExtender) Activator.CreateInstance(type));
+            }
+
+            extenders.Sort((a, b) => a.Weight.CompareTo(b.Weight));
+        }
+
+        internal static void ApplyExtenstionsToPrefab(GameObject prefabInstance, AdrFile adrFile) {
+            foreach (var extender in extenders) {
+                extender.ExtendAdrPrefab(prefabInstance, adrFile);
+            }
+        }
+
+        // Higher runs later
+        public int Weight { get; }
+        /// <summary>
+        /// Extend the prefabInstance GameObject with data specific to the given adr file just before it is saved as a prefab
+        /// </summary>
+        /// <param name="prefabInstance">The GameObject instance that is about to be saved as a prefab that should be extended with custom data</param>
+        /// <param name="adrFile">The adr data instance from the FLTK parsers</param>
+        public void ExtendAdrPrefab(GameObject prefabInstance, AdrFile adrFile);
+    }
+}

--- a/Editor/IAdrExtender.cs.meta
+++ b/Editor/IAdrExtender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e013a142136ffb144bbb928e5a781087
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Importers/AdrImporter.cs
+++ b/Editor/Importers/AdrImporter.cs
@@ -3,15 +3,11 @@ using UnityEditor.AssetImporters;
 
 using ForgeLightToolkit.Editor.FileTypes;
 
-namespace ForgeLightToolkit.Editor.Importers
-{
+namespace ForgeLightToolkit.Editor.Importers {
     [ScriptedImporter(1, "adr")]
-    public class AdrImporter : ScriptedImporter
-    {
-        public override void OnImportAsset(AssetImportContext ctx)
-        {
-            if (string.IsNullOrEmpty(ctx.assetPath))
-            {
+    public class AdrImporter : ScriptedImporter {
+        public override void OnImportAsset(AssetImportContext ctx) {
+            if (string.IsNullOrEmpty(ctx.assetPath)) {
                 ctx.LogImportError($"Invalid asset path. ({ctx.assetPath})");
                 return;
             }
@@ -22,8 +18,7 @@ namespace ForgeLightToolkit.Editor.Importers
             ctx.AddObjectToAsset("Adr", adrFile);
             ctx.SetMainObject(adrFile);
 
-            if (!adrFile.Load(ctx.assetPath))
-            {
+            if (!adrFile.Load(ctx.assetPath)) {
                 ctx.LogImportError($"Failed to load adr file. ({ctx.assetPath})");
                 return;
             }

--- a/Editor/Importers/DmeImporter.cs
+++ b/Editor/Importers/DmeImporter.cs
@@ -3,15 +3,11 @@ using UnityEditor.AssetImporters;
 
 using ForgeLightToolkit.Editor.FileTypes;
 
-namespace ForgeLightToolkit.Editor.Importers
-{
+namespace ForgeLightToolkit.Editor.Importers {
     [ScriptedImporter(1, "dme")]
-    public class DmeImporter : ScriptedImporter
-    {
-        public override void OnImportAsset(AssetImportContext ctx)
-        {
-            if (string.IsNullOrEmpty(ctx.assetPath))
-            {
+    public class DmeImporter : ScriptedImporter {
+        public override void OnImportAsset(AssetImportContext ctx) {
+            if (string.IsNullOrEmpty(ctx.assetPath)) {
                 ctx.LogImportError($"Invalid asset path. ({ctx.assetPath})");
                 return;
             }
@@ -29,8 +25,9 @@ namespace ForgeLightToolkit.Editor.Importers
 
             ctx.AddObjectToAsset("Dma", dmeFile.DmaFile);
 
-            foreach (var meshEntry in dmeFile.Meshes)
+            foreach (var meshEntry in dmeFile.Meshes){
                 ctx.AddObjectToAsset(meshEntry.Mesh.name, meshEntry.Mesh);
+            }
         }
     }
 }

--- a/Editor/LoadWorldWindow.cs
+++ b/Editor/LoadWorldWindow.cs
@@ -496,9 +496,6 @@ namespace ForgeLightToolkit.Editor {
 
         // ReSharper disable Unity.PerformanceAnalysis
         private void LoadAdrFile(string adrFileName, GameObject parentObject, Vector4 position, float scale, Vector4 rotation, int runtimeId = 0) {
-            var adrFilePath = Path.Combine(assetsPath, adrFileName);
-            var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFilePath);
-
             var existingPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(Path.Combine(prefabSavePath, Path.ChangeExtension(adrFileName, "prefab")));
             if (existingPrefab != null && objectsAlreadyProcessed.Contains(adrFileName.Split(".")[0]) && !fastMode) {
                 GameObject loadedObject = PrefabUtility.InstantiatePrefab(existingPrefab, parentObject.transform) as GameObject;
@@ -517,6 +514,9 @@ namespace ForgeLightToolkit.Editor {
 
                 return;
             }
+
+            var adrFilePath = Path.Combine(assetsPath, adrFileName);
+            var adrFile = AssetDatabase.LoadAssetAtPath<AdrFile>(adrFilePath);
 
             if (adrFile == null) {
                 Debug.LogError($"Failed to load Adr. {adrFilePath}");
@@ -656,6 +656,9 @@ namespace ForgeLightToolkit.Editor {
 
                 objectMeshRenderer.material = objectMaterial;
             }
+
+            // Apply the extensions to the adr instance
+            IAdrExtender.ApplyExtenstionsToPrefab(runtimeObject, adrFile);
 
             objectsAlreadyProcessed.Add(runtimeObject.name);
             if (!fastMode) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hybr2d.forgelighttoolkit",
-  "version": "2.5.2-Fork",
+  "version": "2.6.0-Fork",
   "displayName": "ForgeLight Toolkit",
   "description": "ForgeLight Toolkit allows you to import and use ForgeLight assets in Unity.",
   "unity": "2021.3",


### PR DESCRIPTION
Fixed a bug with serialization of ADRs in places where a list was used. The readonly keyword was preventing the re-loading of serialized data, even if it was present when saved